### PR TITLE
feat: Add new OS profile for Ubuntu 24.04

### DIFF
--- a/infra-managers/Chart.yaml
+++ b/infra-managers/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     repository: "file://../telemetry-manager"
   - name: os-resource-manager
     condition: import.os-resource-manager.enabled
-    version: "0.20.0"
+    version: "0.20.1"
     repository: "file://../os-resource-manager"
   - name: attestationstatus-manager
     condition: import.attestationstatus-manager.enabled

--- a/os-resource-manager/Chart.yaml
+++ b/os-resource-manager/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: os-resource-manager
 description: Edge Infrastructure Manager OS Resource Manager
 type: application
-version: 0.20.0
+version: 0.20.1
 appVersion: "0.16.2"
 home: edge-orchestrator.intel.com
 maintainers:

--- a/os-resource-manager/values.yaml
+++ b/os-resource-manager/values.yaml
@@ -62,6 +62,7 @@ managerArgs:
     - microvisor-rt
     - microvisor-nonrt
     - ubuntu-22.04-lts-generic-ext
+    - ubuntu-24.04-lts-generic
   disableProviderAutomation: false
   osSecurityFeatureEnable: false
   # rsProxyRegistryAddress specifies the Release Service OCI Registry proxy address


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Adds the 24.04 Ubuntu OS profile added in https://github.com/open-edge-platform/infra-core/pull/116 to the list of OS profiles in the os-resource-manager chart.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Orchestrator deployed with new OS profile included and updated OS resource manager configuration, new OS profile pulled during pod start up and available in UI for provisioning.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
