### PR TITLE
fix: APIv2 with camelCase resourceId in the URL path

### DIFF
--- a/apiv2/Chart.yaml
+++ b/apiv2/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: apiv2
 description: Edge Infrastructure Manager API
 type: application
-version: 0.3.0
-appVersion: "0.2.1"
+version: 0.3.1
+appVersion: "0.2.2"
 home: edge-orchestrator.intel.com
 maintainers:
   - name: Edge Infrastructure Manager Team

--- a/infra-core/Chart.yaml
+++ b/infra-core/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: infra-core
 description: Edge Infrastructure Manager Core Umbrella Chart
 type: application
-version: "2.11.0"
-appVersion: "2.11.0"
+version: "2.11.1"
+appVersion: "2.11.1"
 annotations: {}
 home: edge-orchestrator.intel.com
 maintainers:
@@ -18,7 +18,7 @@ dependencies:
     repository: "file://../api"
   - name: apiv2
     condition: import.apiv2.enabled
-    version: "0.3.0"
+    version: "0.3.1"
     repository: "file://../apiv2"
   - name: exporter
     condition: import.exporter.enabled


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Bump APIv2 to use the fixed version with camelCase resourceID in the URL path:
- https://github.com/open-edge-platform/infra-core/pull/198

### Any Newly Introduced Dependencies


### How Has This Been Tested?


### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
