### PR TITLE
fix: Mount entire volume to PXE server to avoid conflicts with DKAM

### DIFF
--- a/infra-onboarding/Chart.yaml
+++ b/infra-onboarding/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: infra-onboarding
 description: Edge Infrastructure Manager Onboarding Umbrella Chart
 type: application
-version: "1.32.2"
-appVersion: "1.32.2"
+version: "1.32.3"
+appVersion: "1.32.3"
 annotations: {}
 home: edge-orchestrator.intel.com
 maintainers:
@@ -30,5 +30,5 @@ dependencies:
     repository: "file://../infra-config"
   - name: pxe-server
     condition: import.pxe-server.enabled
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../pxe-server"

--- a/pxe-server/Chart.yaml
+++ b/pxe-server/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: pxe-server
 description: Edge Infrastructure Manager PXE Server
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 home: edge-orchestrator.intel.com
 maintainers:
   - name: Edge Infrastructure Manager Team

--- a/pxe-server/Chart.yaml
+++ b/pxe-server/Chart.yaml
@@ -6,7 +6,7 @@ name: pxe-server
 description: Edge Infrastructure Manager PXE Server
 type: application
 version: 0.1.1
-appVersion: "0.1.1"
+appVersion: "0.1.0"
 home: edge-orchestrator.intel.com
 maintainers:
   - name: Edge Infrastructure Manager Team

--- a/pxe-server/templates/deployment.yaml
+++ b/pxe-server/templates/deployment.yaml
@@ -40,15 +40,14 @@ spec:
         - name: tftp-permissions
           image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
           command: [ "/bin/sh" ]
-          args: [ "-c", "cp /tmp/ipxe.efi /tftp-storage && chmod 640 /tftp-storage/ipxe.efi && chown 65534:65534 /tftp-storage/ipxe.efi" ]
+          args: [ "-c", "cp /pvc/signed_ipxe.efi /tftp-storage/ipxe.efi && chmod 640 /tftp-storage/ipxe.efi && chown 65534:65534 /tftp-storage/ipxe.efi" ]
           volumeMounts:
             {{- if .Values.standaloneMode.enabled }}
             - name: local-path
               mountPath: "/tmp/ipxe.efi"
             {{- else }}
             - name: nginx-pvc
-              mountPath: "/tmp/ipxe.efi"
-              subPath: "signed_ipxe.efi"
+              mountPath: "/pvc"
             {{- end }}
             - name: tftp-storage
               mountPath: /tftp-storage


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Before the single file was mounted but when DKAM takes long time to create signed_ipxe.efi the K8s creates an empty directory for a mounted file. It causes error in DKAM as copying `signed_ipxe.efi` fails. 

The init container mounts the entire volume so that a dumb directory is not created and init container fail until DKAM creates `signed_ipxe.efi`. 

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Tested deployment on Coder.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
