### PR TITLE
disable wifi support for emt boot kit

### DIFF
--- a/infra-onboarding/Chart.yaml
+++ b/infra-onboarding/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: infra-onboarding
 description: Edge Infrastructure Manager Onboarding Umbrella Chart
 type: application
-version: "1.33.7"
-appVersion: "1.33.7"
+version: "1.33.8"
+appVersion: "1.33.8"
 annotations: {}
 home: edge-orchestrator.intel.com
 maintainers:
@@ -22,7 +22,7 @@ dependencies:
     repository: "file://../dkam"
   - name: tinkerbell
     condition: import.tinkerbell.enabled
-    version: "2.12.1"
+    version: "2.12.2"
     repository: "file://../tinkerbell"
   - name: infra-config
     condition: import.infra-config.enabled

--- a/tinkerbell/Chart.yaml
+++ b/tinkerbell/Chart.yaml
@@ -8,7 +8,7 @@ apiVersion: v2
 name: tinkerbell
 description: Edge Infrastructure Manager Tinkerbell Umbrella Chart
 type: application
-version: 2.12.1
+version: 2.12.2
 appVersion: "0.0.1"
 dependencies:
   - name: tinkerbell_tink

--- a/tinkerbell/templates/boot-ipxe-configmap.yaml
+++ b/tinkerbell/templates/boot-ipxe-configmap.yaml
@@ -35,7 +35,7 @@ data:
     initrd --timeout=-1 ${download-url}/initramfs-${arch} && goto bootfinal || iseq ${idx} ${retry_limit} && goto error || inc idx && echo Unable to load ${download-url}/initramfs-${arch} && echo RETRY NO ${idx} && goto initloop
     :bootfinal
     set initramfs_download_end ${unixtime}
-    imgargs vmlinuz-${arch} root=tmpfs rootflags=mode=0755 rd.skipfsck noresume quiet splash modules-load=nbd tink_worker_image=${tink_worker_image} grpc_authority=${grpc_authority} tinkerbell_tls=false worker_id=${bootdevmac} \
+    imgargs vmlinuz-${arch} root=tmpfs rootflags=mode=0755 rd.skipfsck noresume quiet splash modules-load=nbd modprobe.blacklist=iwlwifi tink_worker_image=${tink_worker_image} grpc_authority=${grpc_authority} tinkerbell_tls=false worker_id=${bootdevmac} \
     IP=${bootdevip} \
     $ADDITIONAL_KERNEL_ARGS \
     modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200 loglevel=2 \


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

This change is to disable the wifi/bt firmware drivers from the emt microvisor boot kit . 
Some times few Edge node hardware enabled with wifi/bt firmware, and which is causing emt boot kit stuck while loading the   initramfs && vmlinux files , during the provision time we don't need these firmware disabling them from kernel cmd line.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
