### PR TITLE
Add support for configurable memory for health check service

### DIFF
--- a/infra-config/Chart.yaml
+++ b/infra-config/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: infra-config
 description: Edge Infrastructure Manager Shared Configuration
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "1.0.0"
 annotations: {}
 home: edge-orchestrator.intel.com

--- a/infra-config/values.yaml
+++ b/infra-config/values.yaml
@@ -12,6 +12,7 @@ config:
   enManifestRepo: "edge-orch/en/files/ena-manifest"
   enAgentManifestTag:  latest-dev
   rsType: no-auth
+  maxAgentMemory: 128M
 
   orchInfra: infra-node.kind.internal:443
   orchCluster: cluster-orch-edge-node.kind.internal:443

--- a/infra-onboarding/Chart.yaml
+++ b/infra-onboarding/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: infra-onboarding
 description: Edge Infrastructure Manager Onboarding Umbrella Chart
 type: application
-version: "1.33.9"
-appVersion: "1.33.9"
+version: "1.33.10"
+appVersion: "1.33.10"
 annotations: {}
 home: edge-orchestrator.intel.com
 maintainers:
@@ -26,7 +26,7 @@ dependencies:
     repository: "file://../tinkerbell"
   - name: infra-config
     condition: import.infra-config.enabled
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../infra-config"
   - name: pxe-server
     condition: import.pxe-server.enabled


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Updates the cloud-init to allow for configuration of the MemoryMax setting in the platform-observability-health-check service on the edge node to a non-default value.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
