### PR TITLE
Update sanity-upgrade-test.yml to use SHA for orch-ci

### DIFF
--- a/.github/workflows/sanity-upgrade-test.yml
+++ b/.github/workflows/sanity-upgrade-test.yml
@@ -48,7 +48,7 @@ jobs:
           git config --global url."https://${{ secrets.SYS_EMF_GH_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
       - name: Setup asdf and install dependencies
-        uses: open-edge-platform/orch-ci/.github/actions/setup-asdf@main     # zizmor: ignore[unpinned-uses]
+        uses: open-edge-platform/orch-ci/.github/actions/setup-asdf@a95228137803b756aae327668c115db235802982  # v2026.1.3   zizmor: ignore[unpinned-uses]
 
       - name: Get current git hash of the infra-charts PR
         id: get-git-hash-charts


### PR DESCRIPTION
This pull request makes a small but important update to the GitHub Actions workflow configuration. The `setup-asdf` action is now pinned to a specific commit hash (`a95228137803b756aae327668c115db235802982`) instead of tracking the `main` branch, which improves the reliability and security of the workflow.

* [`.github/workflows/sanity-upgrade-test.yml`](diffhunk://#diff-fd3c3a39cd86081a7c9574705b604360973cad467661ef62ab35a2737d1803c9L51-R51): Pin the `open-edge-platform/orch-ci/.github/actions/setup-asdf` GitHub Action to a specific commit hash for reproducibility and security.