### PR TITLE
Update sanity-tests.yml use SHA for orch-ci referece

### DIFF
--- a/.github/workflows/sanity-tests.yml
+++ b/.github/workflows/sanity-tests.yml
@@ -43,7 +43,7 @@ jobs:
           git config --global url."https://${{ secrets.SYS_EMF_GH_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
       - name: Setup asdf and install dependencies
-        uses: open-edge-platform/orch-ci/.github/actions/setup-asdf@main  # zizmor: ignore[unpinned-uses]
+        uses: open-edge-platform/orch-ci/.github/actions/setup-asdf@a95228137803b756aae327668c115db235802982  # v2026.1.3 zizmor: ignore[unpinned-uses]
 
       - name: Checkout infra-charts repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd    # v6.0.2


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow configuration. The `setup-asdf` action in `.github/workflows/sanity-tests.yml` is now pinned to a specific commit hash instead of using the `main` branch, improving build reliability and security.

* Workflow dependency management:
  * Updated the `uses` reference for `open-edge-platform/orch-ci/.github/actions/setup-asdf` from the `main` branch to a specific commit (`a95228137803b756aae327668c115db235802982`) for more deterministic and secure builds.