### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request introduces a configuration change to Dependabot to help manage update frequency.

- Dependabot configuration: Added a `cooldown` setting with `default-days: 7` in `.github/dependabot.yml` to limit how often Dependabot opens new pull requests for dependency updates.