### PR TITLE
amt/mps: replace vault-token refresh CronJob with long-running Deployment for exact 50-min cadence

### DIFF
--- a/amt/Chart.yaml
+++ b/amt/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: amt
 description: Edge Infrastructure Manager AMT
 type: application
-version: 0.10.3
+version: 0.10.4
 appVersion: "0.7.9"
 home: edge-orchestrator.intel.com
 maintainers:

--- a/amt/Chart.yaml
+++ b/amt/Chart.yaml
@@ -13,11 +13,11 @@ maintainers:
   - name: Edge Infrastructure Manager Team
 dependencies:
   - name: mps
-    version: "0.0.34"
+    version: "0.0.35"
     condition: import.mps.enabled
     repository: "file://charts/mps"
   - name: rps
-    version: "0.0.22"
+    version: "0.0.25"
     condition: import.rps.enabled
     repository: "file://charts/rps"
   - name: dm-manager

--- a/amt/charts/mps/Chart.yaml
+++ b/amt/charts/mps/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: mps
 description: Edge Infrastructure Manager AMT MPS
 type: application
-version: 0.1.0-dev
+version: 0.0.35
 appVersion: "0.0.17"
 annotations: {}
 home: edge-orchestrator.intel.com

--- a/amt/charts/mps/templates/amt-vault-script.yaml
+++ b/amt/charts/mps/templates/amt-vault-script.yaml
@@ -8,7 +8,7 @@ metadata:
   name: amt-vault-script
 data:
   amt.sh: |
-    #!/bin/bash
+    #!/bin/sh
 
     # DO NOT MODIFY - SEE DESCRIPTION
 
@@ -58,7 +58,7 @@ data:
     done
     shift $((OPTIND -1))
 
-    function usage {
+    usage() {
         cat >&2 <<EOF
     Purpose:
     Creation of secret for MPS and RPS services.
@@ -76,7 +76,7 @@ data:
 
     VAULT_URL=$1
 
-    if [[ "$HELP" || -z "$VAULT_URL" ]]; then
+    if [ -n "$HELP" ] || [ -z "$VAULT_URL" ]; then
         usage
         exit 1
     fi
@@ -91,7 +91,7 @@ data:
              "$VAULT_URL/v1/auth/kubernetes/login" \
              -H "Authorization: Bearer $TOKEN" \
              -d '{"jwt": "'"${TOKEN}"'", "role": "orch-svc"}') && \
-          [[ ! "$vault_login_output" =~ "errors" ]]; then
+          ! printf '%s' "$vault_login_output" | grep -q 'errors'; then
         echo "Vault login successful!"
         VAULT_TOKEN=$(echo "$vault_login_output" | jq -r  '.auth.client_token')
         break
@@ -125,14 +125,14 @@ data:
             }
           }')
 
-      if [[ "${POST_RETURN_CODE}" =~ "201" ]]; then
+      if [ "${POST_RETURN_CODE}" = "201" ]; then
         echo "Vault token created successfully!"
         emit_event "success" "secret_create" "vault-token Secret created" "$POST_RETURN_CODE"
         touch /tmp/last_success
         patch_status_cm
         break
       else
-        if [[ "${POST_RETURN_CODE}" =~ "409" ]]; then
+        if [ "${POST_RETURN_CODE}" = "409" ]; then
           PUT_RETURN_CODE=$(curl -s -o /dev/null -w "%{http_code}" -k -X PUT \
             "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/{{ .Release.Namespace }}/secrets/vault-token" \
             -H "Authorization: Bearer $TOKEN" \
@@ -147,7 +147,7 @@ data:
                   "vault-token": "'$(echo -n "$VAULT_TOKEN" | base64 -w0)'"
                 }
               }')
-          if [[ "${PUT_RETURN_CODE}" =~ "200" ]]; then
+          if [ "${PUT_RETURN_CODE}" = "200" ]; then
             echo "Vault token updated successfully!"
             emit_event "success" "secret_update" "vault-token Secret updated" "$PUT_RETURN_CODE"
             touch /tmp/last_success

--- a/amt/charts/mps/templates/amt-vault-script.yaml
+++ b/amt/charts/mps/templates/amt-vault-script.yaml
@@ -21,6 +21,33 @@ data:
     set -xe
     set -o pipefail
 
+    # ITERATION is provided by the refresher Deployment's loop wrapper. The
+    # one-shot bootstrap path (no wrapper) defaults to "init".
+    ITERATION="${ITERATION:-init}"
+    STATUS_CONFIGMAP="${STATUS_CONFIGMAP:-amt-vault-refresh-status}"
+
+    # emit_event prints a single-line JSON record to stdout, captured by the
+    # cluster log stack. Replaces the per-Job history we lost when migrating
+    # from CronJob to a long-running Deployment (see ADR-002).
+    # Args: outcome stage detail [http_status]
+    emit_event() {
+      printf '{"event":"vault_refresh","iteration":"%s","outcome":"%s","stage":"%s","detail":"%s","http_status":"%s","ts":"%s"}\n' \
+        "$ITERATION" "$1" "$2" "$3" "${4:-}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    }
+
+    # patch_status_cm records last successful refresh in the status ConfigMap.
+    # Uses the same projected-SA-token + curl pattern that this script already
+    # uses to write the vault-token Secret below.
+    patch_status_cm() {
+      local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      local next; next="$(( $(date +%s) + ${INTERVAL:-0} ))"
+      curl -s -k -o /dev/null -X PATCH \
+        "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/{{ .Release.Namespace }}/configmaps/${STATUS_CONFIGMAP}" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/merge-patch+json" \
+        -d "{\"data\":{\"lastSuccess\":\"${ts}\",\"lastIteration\":\"${ITERATION}\",\"nextScheduledEpoch\":\"${next}\"}}" || true
+    }
+
     HELP=""
 
     while getopts 'h' flag; do
@@ -70,12 +97,14 @@ data:
         break
       fi
       echo "ERROR: $vault_login_output"
+      emit_event "failure" "vault_login" "vault login attempt failed" ""
       sleep 10
       retry_count=$((retry_count + 1))
     done
 
     if [ $retry_count -eq $max_retries ]; then
       echo "ERROR: Too many errors in logging into Vault!"
+      emit_event "failure" "vault_login" "max_retries_exceeded" ""
       exit 1
     fi
 
@@ -98,6 +127,9 @@ data:
 
       if [[ "${POST_RETURN_CODE}" =~ "201" ]]; then
         echo "Vault token created successfully!"
+        emit_event "success" "secret_create" "vault-token Secret created" "$POST_RETURN_CODE"
+        touch /tmp/last_success
+        patch_status_cm
         break
       else
         if [[ "${POST_RETURN_CODE}" =~ "409" ]]; then
@@ -117,22 +149,32 @@ data:
               }')
           if [[ "${PUT_RETURN_CODE}" =~ "200" ]]; then
             echo "Vault token updated successfully!"
+            emit_event "success" "secret_update" "vault-token Secret updated" "$PUT_RETURN_CODE"
+            touch /tmp/last_success
+            patch_status_cm
             break
           else
             echo "Error creating vault token secret, retrying..."
+            emit_event "failure" "secret_update" "PUT vault-token failed" "$PUT_RETURN_CODE"
             sleep 10
             retry_count=$((retry_count + 1))
           fi
+        else
+          echo "Unexpected POST status, retrying..."
+          emit_event "failure" "secret_create" "unexpected POST status" "$POST_RETURN_CODE"
+          sleep 10
+          retry_count=$((retry_count + 1))
         fi
       fi
     done
 
-    
-    # If Istio proxy is available, quit sidecar
-    if curl -s -f http://127.0.0.1:15020/healthz/ready; then
-       response=$(curl -o /dev/null -w "%{http_code}" --location  -v --request POST http://127.0.0.1:15000/quitquitquit --header 'Content-Type: text/plain')
-       if [[ ! "${response}" =~ "200" ]]; then
-          echo "ERROR: Error while quiting Istio proxy"
-          exit 1
-       fi
+    if [ $retry_count -eq $max_retries ]; then
+      echo "ERROR: Too many errors writing vault-token Secret!"
+      emit_event "failure" "secret_write" "max_retries_exceeded" ""
+      exit 1
     fi
+
+    # Istio sidecar quitquitquit was previously needed because amt.sh ran inside
+    # a one-shot Job that could not terminate while the sidecar was alive. The
+    # script now runs inside a long-running refresher Deployment (ADR-002) that
+    # must keep the mesh up between iterations, so the quit logic is removed.

--- a/amt/charts/mps/templates/amt-vault-script.yaml
+++ b/amt/charts/mps/templates/amt-vault-script.yaml
@@ -28,7 +28,7 @@ data:
 
     # emit_event prints a single-line JSON record to stdout, captured by the
     # cluster log stack. Replaces the per-Job history we lost when migrating
-    # from CronJob to a long-running Deployment (see ADR-002).
+    # from CronJob to a long-running Deployment.
     # Args: outcome stage detail [http_status]
     emit_event() {
       printf '{"event":"vault_refresh","iteration":"%s","outcome":"%s","stage":"%s","detail":"%s","http_status":"%s","ts":"%s"}\n' \
@@ -176,5 +176,5 @@ data:
 
     # Istio sidecar quitquitquit was previously needed because amt.sh ran inside
     # a one-shot Job that could not terminate while the sidecar was alive. The
-    # script now runs inside a long-running refresher Deployment (ADR-002) that
+    # script now runs inside a long-running refresher Deployment that
     # must keep the mesh up between iterations, so the quit logic is removed.

--- a/amt/charts/mps/templates/deployment.yaml
+++ b/amt/charts/mps/templates/deployment.yaml
@@ -12,7 +12,8 @@ metadata:
   name: {{ include "mps.fullname" . }}
   annotations:
     # Reloader annotation to automatically restart deployment when vault-token secret changes
-    # The vault-token secret is renewed every 50 minutes by the amt-vault-job CronJob
+    # The vault-token secret is renewed every {{ div .Values.refresher.intervalSeconds 60 }} minutes by the
+    # {{ .Values.refresher.name }} Deployment (replaces the previous amt-vault-job CronJob; see ADR-002).
     # Reloader watches for secret changes and triggers a rolling restart to prevent 403 errors
     # See: infra-charts/amt/charts/mps/templates/reloader-rbac.yaml for required RBAC
     secret.reloader.stakater.com/reload: "vault-token"

--- a/amt/charts/mps/templates/deployment.yaml
+++ b/amt/charts/mps/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
     # Reloader annotation to automatically restart deployment when vault-token secret changes
     # The vault-token secret is renewed every {{ div .Values.refresher.intervalSeconds 60 }} minutes by the
-    # {{ .Values.refresher.name }} Deployment (replaces the previous amt-vault-job CronJob; see ADR-002).
+    # {{ .Values.refresher.name }} Deployment (replaces the previous amt-vault-job CronJob;).
     # Reloader watches for secret changes and triggers a rolling restart to prevent 403 errors
     # See: infra-charts/amt/charts/mps/templates/reloader-rbac.yaml for required RBAC
     secret.reloader.stakater.com/reload: "vault-token"

--- a/amt/charts/mps/templates/job.yaml
+++ b/amt/charts/mps/templates/job.yaml
@@ -1,63 +1,59 @@
 # SPDX-FileCopyrightText: (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 ---
-apiVersion: batch/v1
-kind: CronJob
+# Status ConfigMap. amt.sh PATCHes `lastSuccess` and `lastIteration` here on
+# every successful refresh. Provides at-a-glance liveness without parsing logs:
+#   kubectl get cm {{ .Values.refresher.statusConfigMap }} -o yaml
+# `resource-policy: keep` so the CM survives `helm uninstall` and retains the
+# last-known refresh state for post-mortem inspection.
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: "{{ .Values.job.name }}"
-spec:
-  schedule: "{{ .Values.job.schedule }}"
-  concurrencyPolicy: Replace
-  jobTemplate:
-    spec:
-      template:
-        metadata:
-          {{- with .Values.podAnnotations }}
-          annotations:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          labels:
-            {{- include "mps.labels" . | nindent 12 }}
-        spec:
-          restartPolicy: OnFailure
-          serviceAccountName: {{ .Values.rbac.serviceaccount }}
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            seccompProfile:
-              type: RuntimeDefault
-          containers:
-            - name: amt
-              image: "{{ .Values.curlImage.name }}:{{ .Values.curlImage.tag }}"
-              imagePullPolicy: {{ .Values.curlImage.pullPolicy }}
-              command: ["/bin/sh"]
-              args: ["/amt.sh", "{{ .Values.mps.vault_url }}"]
-              securityContext:
-                capabilities:
-                  drop:
-                    - ALL
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-              volumeMounts:
-                - mountPath: /amt.sh
-                  subPath: amt.sh
-                  name: amt-vol
-                - mountPath: /tmp
-                  name: tmp-vol
-          volumes:
-            - name: amt-vol
-              configMap:
-                name: amt-vault-script
-                defaultMode: 0777
-            - name: tmp-vol
-              emptyDir: {}
+  name: "{{ .Values.refresher.statusConfigMap }}"
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    {{- include "mps.labels" . | nindent 4 }}
+data:
+  lastSuccess: ""
+  lastIteration: ""
 ---
-# FIXME: ITEP-70124 This job is only a temporary solution to run the amt.sh script once at the beginning of the deployment.
-apiVersion: batch/v1
-kind: Job
+# Long-running Vault token refresher.
+#
+# Why a Deployment + sleep loop instead of a CronJob:
+#   - Cron cannot express an even 50-min cadence (50 does not divide 60). The
+#     previous schedule `*/50 * * * *` fired at :00 and :50, producing a real
+#     gap pattern of 50/10/50/10 min. A user session started right after the
+#     :50 refresh was killed by Reloader ~10 min later when the :00 refresh
+#     fired, far below the required 40-min session guarantee.
+#   - An in-process `sleep {{ .Values.refresher.intervalSeconds }}` produces an
+#     exact spacing, so every freshly-started session is guaranteed at least
+#     `intervalSeconds` of valid token before the next Reloader-triggered roll.
+#
+# Crash semantics: if the pod exits for any reason, the Deployment restarts it
+# and the loop's first action is `amt.sh` (an immediate refresh). One session
+# may be killed earlier than expected, but the next session still gets the full
+# `intervalSeconds`. The crash is recorded in pod restartCount and previous-logs.
+#
+# Single replica + Recreate strategy: there is no benefit to overlapping
+# refreshes, and concurrent refreshers would race on the `vault-token` Secret.
+# HA via leader election (Lease) is deferred — see ADR-002.
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: "init-{{ .Values.job.name }}"
+  name: "{{ .Values.refresher.name }}"
+  labels:
+    {{- include "mps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: vault-refresher
 spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mps
+      app.kubernetes.io/component: vault-refresher
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -65,9 +61,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "mps.labels" . | nindent 8 }}
+        helm.sh/chart: {{ include "mps.chart" . }}
+        app.kubernetes.io/name: {{ include "mps.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/component: vault-refresher
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+        app: mps
     spec:
-      restartPolicy: OnFailure
       serviceAccountName: {{ .Values.rbac.serviceaccount }}
       securityContext:
         runAsNonRoot: true
@@ -78,8 +79,48 @@ spec:
         - name: amt
           image: "{{ .Values.curlImage.name }}:{{ .Values.curlImage.tag }}"
           imagePullPolicy: {{ .Values.curlImage.pullPolicy }}
-          command: ["/bin/sh"]
-          args: ["/amt.sh", "{{ .Values.mps.vault_url }}"]
+          # The loop intentionally exits the container if amt.sh fails (set -e).
+          # kubelet then restarts the pod, which runs a fresh refresh on the
+          # next iteration — leaving a restartCount + previous-logs trail for
+          # operators, similar to what CronJob/Job history used to provide.
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              ITERATION=0
+              while true; do
+                ITERATION=$((ITERATION + 1))
+                export ITERATION
+                /amt.sh "$VAULT_URL"
+                sleep "$INTERVAL"
+              done
+          env:
+            - name: VAULT_URL
+              value: "{{ .Values.mps.vault_url }}"
+            - name: INTERVAL
+              value: "{{ .Values.refresher.intervalSeconds }}"
+            - name: STATUS_CONFIGMAP
+              value: "{{ .Values.refresher.statusConfigMap }}"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # Liveness: amt.sh `touch`es /tmp/last_success after every successful
+          # refresh. If the file mtime falls behind `livenessMaxAgeSeconds`
+          # (e.g. amt.sh hangs mid-iteration, or the loop is wedged), kubelet
+          # restarts the pod and the loop runs an immediate refresh on next
+          # boot. `initialDelaySeconds` allows the first iteration to complete
+          # before the probe starts checking.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "[ $(( $(date +%s) - $(stat -c %Y /tmp/last_success 2>/dev/null || echo 0) )) -lt {{ .Values.refresher.livenessMaxAgeSeconds }} ]"
+            initialDelaySeconds: 120
+            periodSeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 3
           securityContext:
             capabilities:
               drop:

--- a/amt/charts/mps/templates/job.yaml
+++ b/amt/charts/mps/templates/job.yaml
@@ -37,7 +37,7 @@ data:
 #
 # Single replica + Recreate strategy: there is no benefit to overlapping
 # refreshes, and concurrent refreshers would race on the `vault-token` Secret.
-# HA via leader election (Lease) is deferred — see ADR-002.
+# HA via leader election (Lease) is deferred.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/amt/charts/mps/templates/job.yaml
+++ b/amt/charts/mps/templates/job.yaml
@@ -91,7 +91,7 @@ spec:
               while true; do
                 ITERATION=$((ITERATION + 1))
                 export ITERATION
-                /amt.sh "$VAULT_URL"
+                sh /amt.sh "$VAULT_URL"
                 sleep "$INTERVAL"
               done
           env:

--- a/amt/charts/mps/templates/role.yaml
+++ b/amt/charts/mps/templates/role.yaml
@@ -10,6 +10,14 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get","update", "list", "watch", "patch"]
+# Allow the refresher Deployment (running as the same ServiceAccount) to PATCH
+# the status ConfigMap with the timestamp of each successful Vault token
+# refresh. Restricted by resourceNames to a single object so the SA cannot
+# tamper with any other ConfigMap in the namespace.
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["{{ .Values.refresher.statusConfigMap }}"]
+  verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/amt/charts/mps/values.yaml
+++ b/amt/charts/mps/values.yaml
@@ -35,9 +35,25 @@ fullnameOverride: "mps"
 tenancyMiddleware:
   enabled: true
 
+# Long-running Vault token refresher.
+# Replaces the previous CronJob (`*/50 * * * *`), which produced a 50/10/50/10 min
+# gap pattern and could not guarantee a 40-min user session before MPS/RPS were
+# rolled by Reloader. The refresher Deployment runs amt.sh in a sleep loop with
+# an exact `intervalSeconds` cadence. See
+# `edge-manageability-framework/design-proposals/adr-amt-token-vault-refresh.md`.
+refresher:
+  name: amt-vault-refresher
+  # Spacing between two successful Vault token refreshes.
+  # Must be < Vault token TTL (default 60 min) and provide enough headroom for
+  # the longest user session expected against MPS/RPS.
+  intervalSeconds: 3000
+  # Liveness probe fails if /tmp/last_success has not been touched within this
+  # window, causing kubelet to restart the pod and trigger an immediate refresh.
+  livenessMaxAgeSeconds: 3300
+  # Status ConfigMap that amt.sh PATCHes after each successful refresh.
+  statusConfigMap: amt-vault-refresh-status
+
 job:
-  name: amt-vault-job
-  schedule: "*/50 * * * *"
   secretjob:
     name: amt-dbpassword-secret-job
     configmap: mps-db-configmap

--- a/amt/charts/rps/Chart.yaml
+++ b/amt/charts/rps/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: rps
 description: Edge Infrastructure Manager AMT RPS
 type: application
-version: 0.1.0-dev
+version: 0.0.25
 appVersion: "0.0.13"
 annotations: {}
 home: edge-orchestrator.intel.com

--- a/amt/charts/rps/templates/deployment.yaml
+++ b/amt/charts/rps/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
     # Reloader annotation to automatically restart deployment when vault-token secret changes
     # The vault-token secret is renewed every 50 minutes by the amt-vault-refresher Deployment (in MPS chart;
-    # replaces the previous amt-vault-job CronJob; see ADR-002).
+    # replaces the previous amt-vault-job CronJob).
     # Reloader watches for secret changes and triggers a rolling restart to prevent 403 errors
     # See: infra-charts/amt/charts/mps/templates/reloader-rbac.yaml for required RBAC
     secret.reloader.stakater.com/reload: "vault-token"

--- a/amt/charts/rps/templates/deployment.yaml
+++ b/amt/charts/rps/templates/deployment.yaml
@@ -12,7 +12,8 @@ metadata:
   name: {{ include "rps.fullname" . }}
   annotations:
     # Reloader annotation to automatically restart deployment when vault-token secret changes
-    # The vault-token secret is renewed every 50 minutes by the amt-vault-job CronJob (in MPS chart)
+    # The vault-token secret is renewed every 50 minutes by the amt-vault-refresher Deployment (in MPS chart;
+    # replaces the previous amt-vault-job CronJob; see ADR-002).
     # Reloader watches for secret changes and triggers a rolling restart to prevent 403 errors
     # See: infra-charts/amt/charts/mps/templates/reloader-rbac.yaml for required RBAC
     secret.reloader.stakater.com/reload: "vault-token"

--- a/infra-external/Chart.yaml
+++ b/infra-external/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: infra-external
 description: Edge Infrastructure Manager External Umbrella Chart
 type: application
-version: "2.14.4"
+version: "2.14.5"
 appVersion: "2.13.4"
 annotations: {}
 home: edge-orchestrator.intel.com
@@ -30,5 +30,5 @@ dependencies:
     repository: "file://../loca-templates-manager"
   - name: amt
     condition: import.amt.enabled
-    version: "0.10.4"
+    version: "0.10.5"
     repository: "file://../amt"

--- a/infra-external/Chart.yaml
+++ b/infra-external/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: infra-external
 description: Edge Infrastructure Manager External Umbrella Chart
 type: application
-version: "2.14.5"
+version: "2.14.6"
 appVersion: "2.13.5"
 annotations: {}
 home: edge-orchestrator.intel.com


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->
#### Problem

The existing `schedule: "*/50 * * * *"` CronJob does not produce an even 50-minute cadence. Cron evaluates the `/50` expression per hour, so jobs fire at `:00` and `:50` — giving a 50/10/50/10 minute alternating pattern. A KVM/SOL session started just after the `:50` refresh is killed by Reloader only ~10 minutes later when the `:00` job fires and rewrites the `vault-token` Secret. There is no cron expression that can deliver a true 50-minute period (50 does not divide 60 evenly), so an in-process sleep loop is the only correct fix.

#### Solution

Replace the CronJob with a `Deployment` (`replicas: 1`, `Recreate` strategy) that runs `amt.sh` in a `while true; do refresh; sleep 3000; done` loop. This guarantees exactly 50 minutes between every refresh.

### Changes (`infra-charts/amt/charts/mps/`)

- **Deployment** — new `vault-token-refresher` Deployment using the existing curl image and `amt.sh`. `Recreate` strategy ensures no two refresh processes overlap. An `exec` liveness probe on `/tmp/last_success` mtime catches hangs.
- **Init Job removed** — the existing init Job (FIXME ITEP-70124) is removed. The Deployment's first loop iteration runs `amt.sh` immediately at container start and writes the `vault-token` Secret before entering `sleep`, serving the same seeding purpose. MPS may briefly crash-loop (~5–10 s) on a fresh install until that first write completes — the same window that existed between the old init Job being scheduled and the Secret being created. A Helm hook was considered but rejected: it would require hooking the ServiceAccount/Role/RoleBinding too, expanding blast radius for marginal gain.
- **Observability** — each loop iteration emits a structured JSON log line; a `ConfigMap` (`amt-vault-refresh-status`) is PATCHed with `lastSuccess`, `lastIteration`, and `nextScheduled` timestamps via the projected SA token (same auth pattern `amt.sh` already uses), replacing the per-attempt Job history that CronJob previously provided. One additional `get,patch` rule is added to the existing `amt-role`, scoped to this ConfigMap via `resourceNames`.
- **Reloader integration** — unchanged. Same `vault-token` Secret, same write path, same annotation.

### What is not changed

- No image change
- No new platform dependency
- No Vault TTL change
- No changes outside `infra-charts/amt/charts/mps/


Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

# Validation: replace-cron — `infra-external-2.14.6`

**Env:** `orch-10-139-218-33.pid.infra-host.com` | **Profile:** `onprem-vpro` | **Test cadence:** 180s

### Build & deploy
```bash
cd /home/seu/infra-charts && make deps-external && make pack-infra-external
# Patched: helmfile chart → local infra-external-2.14.6.tgz; amt.mps.refresher.intervalSeconds: 180
cd /home/seu/edge-manageability-framework/post-orch && ./post-orch-deploy.sh install
```

### Checks
```bash
helm -n orch-infra history infra-external                                       # rev 1, chart 2.14.6 ✅
kubectl -n orch-infra get cronjob                                               # No resources ✅
kubectl -n orch-infra get deploy amt-vault-refresher -o jsonpath='{.spec.strategy.type}'  # Recreate ✅
kubectl -n orch-infra describe pod -l app=amt-vault-refresher | grep Liveness  # /tmp/last_success mtime ✅
kubectl -n orch-infra get role amt-role -o yaml | grep -A3 configmaps          # get,patch ✅
kubectl -n orch-infra logs amt-vault-refresher-7c5986bb8f-tqxdt | grep vault_refresh
# Iter 1 15:19:06Z +0s | Iter 2 15:22:06Z +180s | Iter 3 15:25:06Z +180s
# Iter 4 15:28:06Z +180s | Iter 5 15:31:06Z +180s | Iter 6 15:34:06Z +180s | Iter 7 15:37:06Z +180s ✅
kubectl -n orch-infra get events --field-selector reason=Reloaded              # mps + rps reloaded ✅
kubectl -n orch-infra get pod -l app=mps -o jsonpath='{..restartCount}'        # 0 ✅
```

### Result
CronJob removed · Deployment (Recreate, 0 restarts) · vault-token seeded at start · **7 iterations, all exactly 180s** (vs old 50/10 alternating pattern) · Reloader fired each cycle · MPS stable.

> **Before merge:** revert `intervalSeconds` override (production = 3000s / 50 min).


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
