### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small but important update to the `.github/workflows/post-merge.yml` workflow configuration. The workflow will now also trigger on any tag push, in addition to pushes to the `main` and `release-*` branches.<!---
  